### PR TITLE
Update Portainer.md

### DIFF
--- a/SelfHosted/Portainer.md
+++ b/SelfHosted/Portainer.md
@@ -40,8 +40,8 @@ volumes:
 ```bash
 docker run -d \
 	--name portainer \
-	-p 9000:9000 \ 
-	-p 9443:9443 \ 
+	-p 9000:9000 \
+	-p 9443:9443 \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v /path/to/data:/data \
 	--restart=unless-stopped \


### PR DESCRIPTION
Removing spaces in the DOCKER CLI part, that could cause an error "docker: invalid reference format"